### PR TITLE
[CICD-002] GitHub Actions による CD パイプラインの構築（ビルド＆プッシュ）(追加バグ改修)

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -18,6 +18,7 @@ WORKDIR /usr/src/app
 
 # Install gcsfuse for Cloud Storage access, as per design documents
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
     gnupg \
     lsb-release \
     curl && \

--- a/docs/03_dd/03_infrastructure_environment_design.md
+++ b/docs/03_dd/03_infrastructure_environment_design.md
@@ -9,13 +9,16 @@ Cloud Runコンテナ内でCloud Storage FUSEを利用し、SQLiteデータベ�
 #### `Dockerfile` (抜粋)
 
 ```Dockerfile
-# Google Cloud SDK for gcsfuse
+# Install gcsfuse and necessary certificates
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
     gnupg \
-    lsb-release && \
+    lsb-release \
+    curl && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
-    apt-get update && apt-get install -y gcsfuse
+    apt-get update && apt-get install -y gcsfuse && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # ... (中略)
 


### PR DESCRIPTION
# ID/連番
CICD-002

# タスク名
GitHub Actions による CD パイプラインの構築（ビルド＆プッシュ）

# 完了条件
main ブランチへのマージ時に Docker イメージがビルドされ、Artifact Registry にプッシュされる。

# 特記事項
CDパイプラインのビルドエラーを修正